### PR TITLE
Disable introspeciton queries in production.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,13 @@ WORKDIR /usr/src/app
 # where available (npm@5+)
 COPY package*.json ./
 
+# Build for development
 RUN npm install
-# If you are building your code for production
+###############################
+# =====PRODUCTION BUILD=======
 # RUN npm ci --only=production
+# ENV NODE_ENV=production
+###############################
 
 # Bundle app source
 COPY . .

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 //const { ApolloServer } = require("apollo-server");
 const { ApolloServer } = require("apollo-server-express");
+const { NoSchemaIntrospectionCustomRule } = require("graphql");
 
 const { ApolloGateway, IntrospectAndCompose, RemoteGraphQLDataSource } = require("@apollo/gateway");
 
@@ -141,7 +142,11 @@ async function startApolloServer(config) {
   const app = express();
   //const httpServer = http.createServer(app);
 
-  const server = new ApolloServer({ gateway });
+  const server = new ApolloServer({ 
+    gateway,
+    // disable introspection in production
+    validationRules: process.env.NODE_ENV === 'production' && [NoSchemaIntrospectionCustomRule],
+  });
 
   console.log('server pre start')
   await server.start()
@@ -157,5 +162,10 @@ async function startApolloServer(config) {
 
 }
 
+if (process.env.NODE_ENV === 'production') {
+  console.log('==RUNNING PRODUCITON BUILD==')
+} else {
+  console.log('running development build')
+}
 const config = readConfig();
 startApolloServer(config);


### PR DESCRIPTION
[Leaving introspection queries enabled for production creates a security hole.](https://www.apollographql.com/blog/why-you-should-disable-graphql-introspection-in-production) This PR disables introspection queries in production builds.

It's accomplished by reading the NODE_ENV environment variable to check if we're running in production. If so, disable introspection queries. No changes are done when running in development mode, introspection queries are still allowed and may be used for development purpouses.

# Testing process
This query is used to test the added functionality:
```gql
query {
  __schema {
    types {
      name
    }
  }
}
```
Running it against a development build it outputs type names as expected:
```json
{
  "data": {
    "__schema": {
      "types": [
        {
          "name": "AcClassificationGQLModel"
        },
        {
          "name": "String"
        },
        {
          "name": "Int"
        },
        {
          "name": "AcClassificationLevelGQLModel"
        },
        {
          "name": "AcClassificationTypeGQLModel"
        },
... snip ...
```

Compared to a production build which outputs errors instead: 
```json
{
  "error": {
    "errors": [
      {
        "message": "GraphQL introspection has been disabled, but the requested query contained the field \"__schema\".",
        "extensions": {
          "code": "GRAPHQL_VALIDATION_FAILED"
        }
... snip ...
```

This is PR is made as part of Hacking Days.
JVF